### PR TITLE
Moved curl_multi_wait call from event-loop to outer loop

### DIFF
--- a/src/bttv_downloader.cpp
+++ b/src/bttv_downloader.cpp
@@ -293,9 +293,9 @@ int main(void)
             if (transfers < downloads.size) {
                 add_download_to_multi_handle(downloads.elements[transfers++], cm);
             }
-
-            if(still_alive) curl_multi_wait(cm, NULL, 0, 1000, NULL);
         }
+
+        if(still_alive) curl_multi_wait(cm, NULL, 0, 1000, NULL);
     } while (still_alive || (transfers < downloads.size));
 
     return 0;


### PR DESCRIPTION
Hello Tsoding!

You currently call `curl_multi_wait(...)` inside the event-loop (`curl_multi_info_read(...)`). This slows down the processing quite a bit, because this way curl will try to block and wait for new activity after each finished download. Instead, you can keep the queue populated and wait for activity later with a single call to `curl_multi_wait(...)`.

The 10-at-a-time-example is doing this, too:
https://curl.haxx.se/libcurl/c/10-at-a-time.html

Old code:
```
$ time ./bttv_downloader 
R: 0 - No error <https://cdn.betterttv.net/emote/54fa8f1401e468494b85b537/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa903b01e468494b85b53f/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa92ee01e468494b85b553/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa9cc901e468494b85b565/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa919901e468494b85b548/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa913701e468494b85b546/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa930801e468494b85b554/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa932201e468494b85b555/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa909b01e468494b85b542/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa8fce01e468494b85b53c/3x>
[snip]

real    0m2,081s
user    0m0,281s
sys     0m1,172s
```

New code:
```
time ./bttv_downloader
R: 0 - No error <https://cdn.betterttv.net/emote/54fa8f1401e468494b85b537/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa928f01e468494b85b54f/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa92ee01e468494b85b553/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa8fce01e468494b85b53c/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa903b01e468494b85b53f/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa913701e468494b85b546/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa9cc901e468494b85b565/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa919901e468494b85b548/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fa909b01e468494b85b542/3x>
R: 0 - No error <https://cdn.betterttv.net/emote/54fb603201abde735115ddb5/3x>
[snip]

real    0m1,486s
user    0m0,219s
sys     0m0,188s
```

Of course, the timing also depends on the internet-connection.
Please try it for yourself.

Cheers!