### PR TITLE
FreeBSD Makefile and include fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 VODUS_PKGS=freetype2 libavcodec libavutil
-VODUS_CXXFLAGS=-Wall -fno-exceptions -std=c++17 -ggdb $(shell pkg-config --cflags $(VODUS_PKGS))
-VODUS_LIBS=$(shell pkg-config --libs $(VODUS_PKGS)) -lgif
+VODUS_CXXFLAGS=-Wall -fno-exceptions -std=c++17 -ggdb `pkg-config --cflags $(VODUS_PKGS)`
+VODUS_LIBS=`pkg-config --libs $(VODUS_PKGS)` -lgif
 
 EMOTE_DOWNLOADER_PKGS=libcurl
-EMOTE_DOWNLOADER_CXXFLAGS=-Wall -fno-exceptions -std=c++17 -ggdb $(shell pkg-config --cflags $(EMOTE_DOWNLOADER_PKGS))
-EMOTE_DOWNLOADER_LIBS=$(shell pkg-config --libs $(EMOTE_DOWNLOADER_PKGS))
+EMOTE_DOWNLOADER_CXXFLAGS=-Wall -fno-exceptions -std=c++17 -ggdb `pkg-config --cflags $(EMOTE_DOWNLOADER_PKGS)`
+EMOTE_DOWNLOADER_LIBS=`pkg-config --libs $(EMOTE_DOWNLOADER_PKGS)`
 
 RENDER_ARGS=--font assets/ComicNeue_Bold.otf --output output.mpeg --font-size 46 --fps 30 --width 600 --height 1080 --limit 20 sample.txt --bitrate 6000000
 

--- a/src/vodus.cpp
+++ b/src/vodus.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <cmath>
+#include <ctime>
 
 #include <algorithm>
 


### PR DESCRIPTION
Same issue as in the Makefile of `tsoding/something`.

Also I fixed the missing include of `<ctime>`. glibc apparently includes it by default but the FreeBSD libc doesn't.

Test environment:
```
[nico@triton ~/Source/vodus (freebsd-build-fix)]$ uname -apKU
FreeBSD triton 12.1-RELEASE-p6 FreeBSD 12.1-RELEASE-p6 GENERIC  amd64 amd64 1201000 1201000
[nico@triton ~/Source/vodus (freebsd-build-fix)]$ cc --version
FreeBSD clang version 8.0.1 (tags/RELEASE_801/final 366581) (based on LLVM 8.0.1)
Target: x86_64-unknown-freebsd12.1
Thread model: posix
InstalledDir: /usr/bin
```