### PR TITLE
Use fetch instead of wget on FreeBSD

### DIFF
--- a/third_party/build_third_party.sh
+++ b/third_party/build_third_party.sh
@@ -6,13 +6,15 @@ set -e
 FFMPEG_VERSION=4.3
 GIFLIB_VERSION=5.2.1
 MAKE=make
+WGET='wget --no-dns-cache'
 
 # TODO(#102): ./build_third_party.sh does not respect other BSD's or Darwin that might not use GNU make
 # Testing is required and the conditions here may have to be changed accordingly.
 if [ `uname -s` = "FreeBSD" ]; then
-	echo INFO : FreeBSD detected. Setting MAKE to gmake.
+	echo INFO : FreeBSD detected. Using gmake and fetch instead.
 	if test -x "/usr/local/bin/gmake"; then
 		MAKE=gmake
+		WGET=fetch
 	else
 		echo "GNU Make is required to build the third-party dependencies."
 		echo "Aborting..."
@@ -21,7 +23,7 @@ if [ `uname -s` = "FreeBSD" ]; then
 fi
 
 if [ ! -d "ffmpeg-${FFMPEG_VERSION}-dist" ]; then
-    wget --no-dns-cache "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
+    $WGET "https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.xz"
     tar fvx "ffmpeg-${FFMPEG_VERSION}.tar.xz"
     mkdir "ffmpeg-${FFMPEG_VERSION}-dist"
     
@@ -33,7 +35,7 @@ if [ ! -d "ffmpeg-${FFMPEG_VERSION}-dist" ]; then
 fi
 
 if [ ! -d "giflib-${GIFLIB_VERSION}-dist" ]; then
-    wget --no-dns-cache "https://deac-riga.dl.sourceforge.net/project/giflib/giflib-${GIFLIB_VERSION}.tar.gz"
+    $WGET "https://deac-riga.dl.sourceforge.net/project/giflib/giflib-${GIFLIB_VERSION}.tar.gz"
     tar fvx "giflib-${GIFLIB_VERSION}.tar.gz"
     # NOTE: Taken from here https://sourceforge.net/p/giflib/bugs/133/
     patch "giflib-${GIFLIB_VERSION}/Makefile" < Makefile.patch


### PR DESCRIPTION
Since wget is a GNU tool, it doesn't come by default with
FreeBSD. Instead we wanna use fetch, which will always be available on
that platform. The change just adds another variable that will be set
accordingly whenever a FreeBSD system is discovered. Since it might
also apply to different operating systems, testing may be required.

I discovered this issue while I was testing the build of vodus on my main development machine, where I didn't have wget installed